### PR TITLE
Add My Team page with user team API integration

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -167,3 +167,85 @@ class MatchFilters(BaseModel):
     gameweek: Optional[int] = None
     team: Optional[str] = None
     finished: Optional[bool] = None
+
+
+# User Team Models
+class UserTeamPlayerInfo(BaseModel):
+    id: Optional[int]
+    web_name: Optional[str]
+    first_name: Optional[str]
+    second_name: Optional[str]
+    team: Optional[str]
+    team_short_name: Optional[str]
+    position: Optional[str]
+    now_cost: Optional[float]
+    total_points: Optional[int]
+    selected_by_percent: Optional[float]
+    event_points: Optional[int] = None
+    status: Optional[str] = None
+
+
+class UserTeamPick(BaseModel):
+    element: Optional[int]
+    position: Optional[int]
+    multiplier: Optional[int]
+    is_captain: bool = False
+    is_vice_captain: bool = False
+    player: UserTeamPlayerInfo
+
+
+class UserTeamHistoryEntry(BaseModel):
+    event: Optional[int]
+    points: Optional[int]
+    total_points: Optional[int]
+    rank: Optional[int]
+    overall_rank: Optional[int]
+    event_transfers: Optional[int]
+    event_transfers_cost: Optional[int]
+    bank: Optional[float]
+    value: Optional[float]
+    points_on_bench: Optional[int]
+
+
+class UserTeamPastSeason(BaseModel):
+    season_name: Optional[str]
+    total_points: Optional[int]
+    rank: Optional[int]
+
+
+class UserTeamHistory(BaseModel):
+    current: List[UserTeamHistoryEntry]
+    past: List[UserTeamPastSeason]
+
+
+class UserTeamSummary(BaseModel):
+    id: Optional[int]
+    name: Optional[str]
+    player_first_name: Optional[str]
+    player_last_name: Optional[str]
+    player_region_name: Optional[str]
+    summary_overall_points: Optional[int]
+    summary_overall_rank: Optional[int]
+    summary_event_points: Optional[int]
+    summary_event_rank: Optional[int]
+    summary_event_transfers: Optional[int]
+    summary_event_transfers_cost: Optional[int]
+    current_event: Optional[int]
+    total_transfers: Optional[int]
+    team_value: Optional[float]
+    bank: Optional[float]
+    favourite_team: Optional[str]
+    favourite_team_name: Optional[str] = None
+    joined_time: Optional[datetime]
+
+
+class UserTeamResponse(BaseModel):
+    team: UserTeamSummary
+    current_event: Optional[int]
+    current_event_summary: Optional[UserTeamHistoryEntry]
+    picks: List[UserTeamPick]
+    bench: List[UserTeamPick]
+    chips: List[dict]
+    history: UserTeamHistory
+    source: str
+    fetched_at: datetime

--- a/backend/app/routes/user_teams.py
+++ b/backend/app/routes/user_teams.py
@@ -1,0 +1,44 @@
+"""API routes for interacting with Fantasy Premier League manager teams."""
+
+from typing import Optional
+
+import httpx
+from fastapi import APIRouter, HTTPException, Query
+
+from app.models import UserTeamResponse
+from app.services.fpl_service import fpl_service
+
+
+router = APIRouter()
+
+
+@router.get("/user-teams/{team_id}", response_model=UserTeamResponse)
+async def get_user_team(
+    team_id: int,
+    event: Optional[int] = Query(
+        None, description="Optional gameweek to fetch picks for"
+    ),
+):
+    """Return details for a specific Fantasy Premier League entry."""
+
+    try:
+        return await fpl_service.get_user_team(team_id, event)
+    except httpx.HTTPStatusError as exc:  # pragma: no cover - network failure fallback
+        if team_id == 266343:
+            # Provide the curated example for offline development when the
+            # upstream service blocks the request (common during CI runs).
+            return fpl_service.get_sample_user_team()
+
+        if exc.response.status_code == 404:
+            raise HTTPException(status_code=404, detail="Team not found") from exc
+        raise HTTPException(
+            status_code=exc.response.status_code,
+            detail="Fantasy Premier League service returned an error",
+        ) from exc
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        if team_id == 266343:
+            return fpl_service.get_sample_user_team()
+        raise HTTPException(
+            status_code=502,
+            detail="Unable to retrieve FPL team information",
+        ) from exc

--- a/backend/app/services/fpl_service.py
+++ b/backend/app/services/fpl_service.py
@@ -1,0 +1,690 @@
+"""Service helpers for interacting with the public Fantasy Premier League API."""
+
+from __future__ import annotations
+
+import copy
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+import httpx
+
+
+def _convert_currency(value: Optional[int]) -> Optional[float]:
+    """Convert FPL currency values that are stored as tenths into floats."""
+
+    if value is None:
+        return None
+    try:
+        return round(float(value) / 10.0, 1)
+    except (TypeError, ValueError):
+        return None
+
+
+class FPLService:
+    """Utility class for retrieving Fantasy Premier League entry data."""
+
+    BASE_URL = "https://fantasy.premierleague.com/api"
+    USER_AGENT = (
+        "Mozilla/5.0 (compatible; FPLInsightsBot/1.0; +https://github.com/)"
+    )
+
+    def __init__(self) -> None:
+        self._bootstrap_cache: Optional[Dict[str, Any]] = None
+        self._bootstrap_cache_expiry: Optional[datetime] = None
+
+        # Pre-computed example payload which can be returned when the live
+        # service is unreachable. The request from the user specifically
+        # references the entry id ``266343`` so the sample mirrors that id.
+        self._sample_payload: Dict[str, Any] = {
+            "team": {
+                "id": 266343,
+                "name": "Insights XI",
+                "player_first_name": "Alex",
+                "player_last_name": "Johnson",
+                "player_region_name": "England",
+                "summary_overall_points": 412,
+                "summary_overall_rank": 158243,
+                "summary_event_points": 82,
+                "summary_event_rank": 85231,
+                "summary_event_transfers": 1,
+                "summary_event_transfers_cost": 4,
+                "current_event": 5,
+                "total_transfers": 12,
+                "team_value": 101.7,
+                "bank": 1.8,
+                "favourite_team": 12,
+                "favourite_team_name": "Liverpool",
+                "joined_time": "2025-08-10T10:15:00Z",
+            },
+            "current_event": 5,
+            "current_event_summary": {
+                "event": 5,
+                "points": 82,
+                "total_points": 412,
+                "rank": 85231,
+                "overall_rank": 158243,
+                "event_transfers": 1,
+                "event_transfers_cost": 4,
+                "bank": 1.8,
+                "value": 101.7,
+                "points_on_bench": 7,
+            },
+            "chips": [
+                {
+                    "name": "wildcard",
+                    "status_for_entry": "played",
+                    "played_by_entry": True,
+                    "event": 3,
+                },
+                {
+                    "name": "bench_boost",
+                    "status_for_entry": "available",
+                    "played_by_entry": False,
+                    "event": None,
+                },
+            ],
+            "picks": [
+                {
+                    "element": 207,
+                    "position": 1,
+                    "multiplier": 1,
+                    "is_captain": False,
+                    "is_vice_captain": False,
+                    "player": {
+                        "id": 207,
+                        "web_name": "Areola",
+                        "first_name": "Alphonse",
+                        "second_name": "Areola",
+                        "team": "West Ham United",
+                        "team_short_name": "WHU",
+                        "position": "GK",
+                        "now_cost": 4.1,
+                        "total_points": 135,
+                        "selected_by_percent": 27.4,
+                    },
+                },
+                {
+                    "element": 180,
+                    "position": 2,
+                    "multiplier": 1,
+                    "is_captain": False,
+                    "is_vice_captain": False,
+                    "player": {
+                        "id": 180,
+                        "web_name": "Alexander-Arnold",
+                        "first_name": "Trent",
+                        "second_name": "Alexander-Arnold",
+                        "team": "Liverpool",
+                        "team_short_name": "LIV",
+                        "position": "DEF",
+                        "now_cost": 7.5,
+                        "total_points": 178,
+                        "selected_by_percent": 28.9,
+                    },
+                },
+                {
+                    "element": 27,
+                    "position": 3,
+                    "multiplier": 1,
+                    "is_captain": False,
+                    "is_vice_captain": False,
+                    "player": {
+                        "id": 27,
+                        "web_name": "Gabriel",
+                        "first_name": "Gabriel",
+                        "second_name": "Magalhães",
+                        "team": "Arsenal",
+                        "team_short_name": "ARS",
+                        "position": "DEF",
+                        "now_cost": 5.1,
+                        "total_points": 152,
+                        "selected_by_percent": 19.4,
+                    },
+                },
+                {
+                    "element": 270,
+                    "position": 4,
+                    "multiplier": 1,
+                    "is_captain": False,
+                    "is_vice_captain": False,
+                    "player": {
+                        "id": 270,
+                        "web_name": "Estupiñán",
+                        "first_name": "Pervis",
+                        "second_name": "Estupiñán",
+                        "team": "Brighton",
+                        "team_short_name": "BHA",
+                        "position": "DEF",
+                        "now_cost": 5.2,
+                        "total_points": 133,
+                        "selected_by_percent": 15.2,
+                    },
+                },
+                {
+                    "element": 340,
+                    "position": 5,
+                    "multiplier": 1,
+                    "is_captain": False,
+                    "is_vice_captain": False,
+                    "player": {
+                        "id": 340,
+                        "web_name": "Porro",
+                        "first_name": "Pedro",
+                        "second_name": "Porro",
+                        "team": "Tottenham Hotspur",
+                        "team_short_name": "TOT",
+                        "position": "DEF",
+                        "now_cost": 5.9,
+                        "total_points": 164,
+                        "selected_by_percent": 21.3,
+                    },
+                },
+                {
+                    "element": 13,
+                    "position": 6,
+                    "multiplier": 2,
+                    "is_captain": True,
+                    "is_vice_captain": False,
+                    "player": {
+                        "id": 13,
+                        "web_name": "Salah",
+                        "first_name": "Mohamed",
+                        "second_name": "Salah",
+                        "team": "Liverpool",
+                        "team_short_name": "LIV",
+                        "position": "MID",
+                        "now_cost": 12.6,
+                        "total_points": 228,
+                        "selected_by_percent": 54.2,
+                    },
+                },
+                {
+                    "element": 36,
+                    "position": 7,
+                    "multiplier": 1,
+                    "is_captain": False,
+                    "is_vice_captain": True,
+                    "player": {
+                        "id": 36,
+                        "web_name": "Saka",
+                        "first_name": "Bukayo",
+                        "second_name": "Saka",
+                        "team": "Arsenal",
+                        "team_short_name": "ARS",
+                        "position": "MID",
+                        "now_cost": 9.4,
+                        "total_points": 214,
+                        "selected_by_percent": 46.8,
+                    },
+                },
+                {
+                    "element": 420,
+                    "position": 8,
+                    "multiplier": 1,
+                    "is_captain": False,
+                    "is_vice_captain": False,
+                    "player": {
+                        "id": 420,
+                        "web_name": "Son",
+                        "first_name": "Heung-Min",
+                        "second_name": "Son",
+                        "team": "Tottenham Hotspur",
+                        "team_short_name": "TOT",
+                        "position": "MID",
+                        "now_cost": 9.6,
+                        "total_points": 216,
+                        "selected_by_percent": 32.7,
+                    },
+                },
+                {
+                    "element": 640,
+                    "position": 9,
+                    "multiplier": 1,
+                    "is_captain": False,
+                    "is_vice_captain": False,
+                    "player": {
+                        "id": 640,
+                        "web_name": "Palmer",
+                        "first_name": "Cole",
+                        "second_name": "Palmer",
+                        "team": "Chelsea",
+                        "team_short_name": "CHE",
+                        "position": "MID",
+                        "now_cost": 6.1,
+                        "total_points": 196,
+                        "selected_by_percent": 42.1,
+                    },
+                },
+                {
+                    "element": 47,
+                    "position": 10,
+                    "multiplier": 1,
+                    "is_captain": False,
+                    "is_vice_captain": False,
+                    "player": {
+                        "id": 47,
+                        "web_name": "Haaland",
+                        "first_name": "Erling",
+                        "second_name": "Haaland",
+                        "team": "Manchester City",
+                        "team_short_name": "MCI",
+                        "position": "FWD",
+                        "now_cost": 14.3,
+                        "total_points": 264,
+                        "selected_by_percent": 88.5,
+                    },
+                },
+                {
+                    "element": 583,
+                    "position": 11,
+                    "multiplier": 1,
+                    "is_captain": False,
+                    "is_vice_captain": False,
+                    "player": {
+                        "id": 583,
+                        "web_name": "Watkins",
+                        "first_name": "Ollie",
+                        "second_name": "Watkins",
+                        "team": "Aston Villa",
+                        "team_short_name": "AVL",
+                        "position": "FWD",
+                        "now_cost": 8.4,
+                        "total_points": 208,
+                        "selected_by_percent": 41.2,
+                    },
+                },
+            ],
+            "bench": [
+                {
+                    "element": 1,
+                    "position": 12,
+                    "multiplier": 0,
+                    "is_captain": False,
+                    "is_vice_captain": False,
+                    "player": {
+                        "id": 1,
+                        "web_name": "Turner",
+                        "first_name": "Matt",
+                        "second_name": "Turner",
+                        "team": "Nottingham Forest",
+                        "team_short_name": "NFO",
+                        "position": "GK",
+                        "now_cost": 4.0,
+                        "total_points": 76,
+                        "selected_by_percent": 5.4,
+                    },
+                },
+                {
+                    "element": 437,
+                    "position": 13,
+                    "multiplier": 0,
+                    "is_captain": False,
+                    "is_vice_captain": False,
+                    "player": {
+                        "id": 437,
+                        "web_name": "Udogie",
+                        "first_name": "Destiny",
+                        "second_name": "Udogie",
+                        "team": "Tottenham Hotspur",
+                        "team_short_name": "TOT",
+                        "position": "DEF",
+                        "now_cost": 4.9,
+                        "total_points": 118,
+                        "selected_by_percent": 12.3,
+                    },
+                },
+                {
+                    "element": 464,
+                    "position": 14,
+                    "multiplier": 0,
+                    "is_captain": False,
+                    "is_vice_captain": False,
+                    "player": {
+                        "id": 464,
+                        "web_name": "Andreas",
+                        "first_name": "Andreas",
+                        "second_name": "Pereira",
+                        "team": "Fulham",
+                        "team_short_name": "FUL",
+                        "position": "MID",
+                        "now_cost": 5.5,
+                        "total_points": 112,
+                        "selected_by_percent": 6.1,
+                    },
+                },
+                {
+                    "element": 427,
+                    "position": 15,
+                    "multiplier": 0,
+                    "is_captain": False,
+                    "is_vice_captain": False,
+                    "player": {
+                        "id": 427,
+                        "web_name": "Archer",
+                        "first_name": "Cameron",
+                        "second_name": "Archer",
+                        "team": "Sheffield United",
+                        "team_short_name": "SHU",
+                        "position": "FWD",
+                        "now_cost": 4.5,
+                        "total_points": 84,
+                        "selected_by_percent": 9.8,
+                    },
+                },
+            ],
+            "history": {
+                "current": [
+                    {
+                        "event": 5,
+                        "points": 82,
+                        "total_points": 412,
+                        "rank": 85231,
+                        "overall_rank": 158243,
+                        "event_transfers": 1,
+                        "event_transfers_cost": 4,
+                        "bank": 1.8,
+                        "value": 101.7,
+                        "points_on_bench": 7,
+                    },
+                    {
+                        "event": 4,
+                        "points": 79,
+                        "total_points": 330,
+                        "rank": 123114,
+                        "overall_rank": 178452,
+                        "event_transfers": 2,
+                        "event_transfers_cost": 4,
+                        "bank": 1.3,
+                        "value": 101.2,
+                        "points_on_bench": 5,
+                    },
+                    {
+                        "event": 3,
+                        "points": 68,
+                        "total_points": 251,
+                        "rank": 301223,
+                        "overall_rank": 232540,
+                        "event_transfers": 3,
+                        "event_transfers_cost": 8,
+                        "bank": 0.4,
+                        "value": 100.3,
+                        "points_on_bench": 4,
+                    },
+                    {
+                        "event": 2,
+                        "points": 58,
+                        "total_points": 183,
+                        "rank": 612334,
+                        "overall_rank": 342117,
+                        "event_transfers": 1,
+                        "event_transfers_cost": 0,
+                        "bank": 0.9,
+                        "value": 100.7,
+                        "points_on_bench": 6,
+                    },
+                    {
+                        "event": 1,
+                        "points": 101,
+                        "total_points": 125,
+                        "rank": 10234,
+                        "overall_rank": 10234,
+                        "event_transfers": 0,
+                        "event_transfers_cost": 0,
+                        "bank": 0.5,
+                        "value": 100.0,
+                        "points_on_bench": 3,
+                    },
+                ],
+                "past": [
+                    {
+                        "season_name": "2024/25",
+                        "total_points": 2398,
+                        "rank": 48231,
+                    },
+                    {
+                        "season_name": "2023/24",
+                        "total_points": 2312,
+                        "rank": 105234,
+                    },
+                ],
+            },
+            "source": "sample",
+        }
+
+    async def _get_json(self, endpoint: str) -> Dict[str, Any]:
+        """Fetch a JSON document from the public FPL API."""
+
+        headers = {
+            "User-Agent": self.USER_AGENT,
+            "Referer": "https://fantasy.premierleague.com/",
+        }
+
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.get(f"{self.BASE_URL}{endpoint}", headers=headers)
+            response.raise_for_status()
+            return response.json()
+
+    async def _get_bootstrap(self) -> Dict[str, Any]:
+        """Retrieve and cache the bootstrap-static dataset."""
+
+        now = datetime.now(timezone.utc)
+        if (
+            self._bootstrap_cache is not None
+            and self._bootstrap_cache_expiry is not None
+            and now < self._bootstrap_cache_expiry
+        ):
+            return self._bootstrap_cache
+
+        data = await self._get_json("/bootstrap-static/")
+        # Cache for one hour to avoid repeated network calls
+        self._bootstrap_cache = data
+        self._bootstrap_cache_expiry = now + timedelta(hours=1)
+        return data
+
+    @staticmethod
+    def _format_entry(entry: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalise the entry payload into a UI friendly structure."""
+
+        formatted = {
+            "id": entry.get("id"),
+            "name": entry.get("name"),
+            "player_first_name": entry.get("player_first_name"),
+            "player_last_name": entry.get("player_last_name"),
+            "player_region_name": entry.get("player_region_name"),
+            "summary_overall_points": entry.get("summary_overall_points"),
+            "summary_overall_rank": entry.get("summary_overall_rank"),
+            "summary_event_points": entry.get("summary_event_points"),
+            "summary_event_rank": entry.get("summary_event_rank"),
+            "summary_event_transfers": entry.get("summary_event_transfers"),
+            "summary_event_transfers_cost": entry.get("summary_event_transfers_cost"),
+            "current_event": entry.get("current_event"),
+            "total_transfers": entry.get("summary_total_transfers")
+            or entry.get("summary_overall_transfers"),
+            "team_value": _convert_currency(entry.get("value")),
+            "bank": _convert_currency(entry.get("bank")),
+            "favourite_team": entry.get("favourite_team"),
+            "favourite_team_name": entry.get("favourite_team_name"),
+            "joined_time": entry.get("joined_time"),
+        }
+
+        # Attempt to look up the fan's favourite club name from the leagues data
+        leagues = entry.get("leagues") or {}
+        classic_leagues = leagues.get("classic") if isinstance(leagues, dict) else None
+        if formatted.get("favourite_team") and classic_leagues:
+            try:
+                favourite = next(
+                    (
+                        league
+                        for league in classic_leagues
+                        if league.get("league_type") == "favourite"
+                    ),
+                    None,
+                )
+                if favourite and favourite.get("name"):
+                    formatted["favourite_team_name"] = favourite.get("name")
+            except (TypeError, StopIteration):
+                pass
+
+        return formatted
+
+    @staticmethod
+    def _format_pick(
+        pick: Dict[str, Any],
+        players_by_id: Dict[int, Dict[str, Any]],
+        teams_by_id: Dict[int, Dict[str, Any]],
+        positions_by_id: Dict[int, str],
+    ) -> Dict[str, Any]:
+        """Merge pick data with player metadata from bootstrap-static."""
+
+        element_id = pick.get("element")
+        player_info = players_by_id.get(element_id, {})
+        team_info = teams_by_id.get(player_info.get("team")) if player_info else None
+
+        player_payload = {
+            "id": player_info.get("id"),
+            "web_name": player_info.get("web_name"),
+            "first_name": player_info.get("first_name"),
+            "second_name": player_info.get("second_name"),
+            "team": team_info.get("name") if team_info else None,
+            "team_short_name": team_info.get("short_name") if team_info else None,
+            "position": positions_by_id.get(player_info.get("element_type")),
+            "now_cost": _convert_currency(player_info.get("now_cost")),
+            "total_points": player_info.get("total_points"),
+            "selected_by_percent": (
+                float(player_info.get("selected_by_percent", 0.0))
+                if player_info.get("selected_by_percent") is not None
+                else None
+            ),
+            "event_points": player_info.get("event_points"),
+            "status": player_info.get("status"),
+        }
+
+        return {
+            "element": element_id,
+            "position": pick.get("position"),
+            "multiplier": pick.get("multiplier"),
+            "is_captain": pick.get("is_captain", False),
+            "is_vice_captain": pick.get("is_vice_captain", False),
+            "player": player_payload,
+        }
+
+    @staticmethod
+    def _format_history(history: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalise the history payload by converting currency fields."""
+
+        if not history:
+            return {"current": [], "past": []}
+
+        current_entries = []
+        for event in history.get("current", []):
+            current_entries.append(
+                {
+                    "event": event.get("event"),
+                    "points": event.get("points"),
+                    "total_points": event.get("total_points"),
+                    "rank": event.get("rank"),
+                    "overall_rank": event.get("overall_rank"),
+                    "event_transfers": event.get("event_transfers"),
+                    "event_transfers_cost": event.get("event_transfers_cost"),
+                    "bank": _convert_currency(event.get("bank")),
+                    "value": _convert_currency(event.get("value")),
+                    "points_on_bench": event.get("points_on_bench"),
+                }
+            )
+
+        past_entries = []
+        for season in history.get("past", []):
+            past_entries.append(
+                {
+                    "season_name": season.get("season_name"),
+                    "total_points": season.get("total_points"),
+                    "rank": season.get("rank"),
+                }
+            )
+
+        return {"current": current_entries, "past": past_entries}
+
+    async def get_user_team(
+        self, team_id: int, event: Optional[int] = None
+    ) -> Dict[str, Any]:
+        """Retrieve a Fantasy Premier League entry with enriched pick details."""
+
+        entry_data = await self._get_json(f"/entry/{team_id}/")
+        history_data = await self._get_json(f"/entry/{team_id}/history/")
+
+        current_event = event or entry_data.get("current_event")
+        if current_event is None:
+            current = history_data.get("current") or []
+            if current:
+                current_event = current[-1].get("event")
+
+        if current_event is None:
+            raise ValueError("Unable to determine the current event for the entry")
+
+        picks_data = await self._get_json(
+            f"/entry/{team_id}/event/{current_event}/picks/"
+        )
+
+        bootstrap = await self._get_bootstrap()
+        players_by_id = {
+            element.get("id"): element for element in bootstrap.get("elements", [])
+        }
+        teams_by_id = {
+            team.get("id"): team for team in bootstrap.get("teams", [])
+        }
+        positions_by_id = {
+            element_type.get("id"): element_type.get("singular_name_short")
+            for element_type in bootstrap.get("element_types", [])
+        }
+
+        formatted_picks = [
+            self._format_pick(pick, players_by_id, teams_by_id, positions_by_id)
+            for pick in picks_data.get("picks", [])
+        ]
+
+        # Separate starting XI and bench
+        starting = [pick for pick in formatted_picks if (pick.get("position") or 0) <= 11]
+        bench = [pick for pick in formatted_picks if (pick.get("position") or 0) > 11]
+
+        response = {
+            "team": self._format_entry(entry_data),
+            "current_event": current_event,
+            "current_event_summary": {
+                "event": current_event,
+                "points": picks_data.get("entry_history", {}).get("points"),
+                "total_points": picks_data.get("entry_history", {}).get("total_points"),
+                "rank": picks_data.get("entry_history", {}).get("rank"),
+                "overall_rank": picks_data.get("entry_history", {}).get("overall_rank"),
+                "event_transfers": picks_data.get("entry_history", {}).get("event_transfers"),
+                "event_transfers_cost": picks_data.get("entry_history", {}).get(
+                    "event_transfers_cost"
+                ),
+                "bank": _convert_currency(picks_data.get("entry_history", {}).get("bank")),
+                "value": _convert_currency(
+                    picks_data.get("entry_history", {}).get("value")
+                ),
+                "points_on_bench": picks_data.get("entry_history", {}).get(
+                    "points_on_bench"
+                ),
+            },
+            "chips": picks_data.get("chips", []),
+            "picks": starting,
+            "bench": bench,
+            "history": self._format_history(history_data),
+            "source": "live",
+            "fetched_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+        return response
+
+    def get_sample_user_team(self) -> Dict[str, Any]:
+        """Return an example payload for offline development."""
+
+        sample = copy.deepcopy(self._sample_payload)
+        sample["fetched_at"] = datetime.now(timezone.utc).isoformat()
+        return sample
+
+
+# Global service instance used by the API routers
+fpl_service = FPLService()
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routes import players, teams, matches, dashboard
+from app.routes import players, teams, matches, dashboard, user_teams
 from dotenv import load_dotenv
 
 # Load environment variables
@@ -30,6 +30,7 @@ app.include_router(players.router, prefix="/api", tags=["players"])
 app.include_router(teams.router, prefix="/api", tags=["teams"])
 app.include_router(matches.router, prefix="/api", tags=["matches"])
 app.include_router(dashboard.router, prefix="/api", tags=["dashboard"])
+app.include_router(user_teams.router, prefix="/api", tags=["user-teams"])
 
 
 @app.get("/")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ pandas==2.2.0
 supabase==2.7.0
 python-dotenv==1.0.0
 python-multipart==0.0.9
+httpx==0.28.1

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import Teams from './pages/Teams';
 import Matches from './pages/Matches';
 import PlayerDetail from './pages/PlayerDetail';
 import TeamDetail from './pages/TeamDetail';
+import MyTeam from './pages/MyTeam';
 import Layout from './components/Layout';
 
 // Create a client
@@ -31,6 +32,7 @@ function App() {
             <Route path="/teams" element={<Teams />} />
             <Route path="/teams/:id" element={<TeamDetail />} />
             <Route path="/matches" element={<Matches />} />
+            <Route path="/my-team" element={<MyTeam />} />
           </Routes>
         </Layout>
       </Router>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from 'react-router-dom';
-import { BarChart3, Users, Shield, Calendar, Home } from 'lucide-react';
+import { BarChart3, Users, Shield, Calendar, Home, UserCircle2 } from 'lucide-react';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -10,6 +10,7 @@ const Layout = ({ children }: LayoutProps) => {
 
   const navigation = [
     { name: 'Dashboard', href: '/', icon: Home },
+    { name: 'My Team', href: '/my-team', icon: UserCircle2 },
     { name: 'Players', href: '/players', icon: Users },
     { name: 'Teams', href: '/teams', icon: Shield },
     { name: 'Matches', href: '/matches', icon: Calendar },

--- a/frontend/src/hooks/useFPLData.ts
+++ b/frontend/src/hooks/useFPLData.ts
@@ -136,3 +136,18 @@ export const useSearchTeams = (query: string) => {
     staleTime: 30 * 1000,
   });
 };
+
+export const useUserTeam = (teamId?: number, event?: number) => {
+  return useQuery({
+    queryKey: ['userTeam', teamId, event],
+    queryFn: () => {
+      if (!teamId) {
+        throw new Error('Team ID is required');
+      }
+      return apiService.getUserTeam(teamId, event);
+    },
+    enabled: typeof teamId === 'number' && teamId > 0,
+    staleTime: 60 * 1000,
+    retry: 1,
+  });
+};

--- a/frontend/src/pages/MyTeam.tsx
+++ b/frontend/src/pages/MyTeam.tsx
@@ -1,0 +1,526 @@
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import { AlertCircle, RefreshCcw, Trophy, Users, Star } from 'lucide-react';
+import { useUserTeam } from '../hooks/useFPLData';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '../components/ui/Card';
+import { Badge } from '../components/ui/Badge';
+import LoadingSpinner from '../components/LoadingSpinner';
+import type { UserTeamPick, UserTeamHistoryEntry } from '../types/fpl';
+
+const DEFAULT_TEAM_ID = 266343;
+const STORAGE_KEY = 'fpl-insights.team-id';
+
+interface ChipInfo {
+  name?: string;
+  status_for_entry?: string;
+  played_by_entry?: boolean;
+  event?: number | null;
+}
+
+const formatNumber = (value?: number | null) => {
+  if (value == null || Number.isNaN(value)) {
+    return '—';
+  }
+  return value.toLocaleString();
+};
+
+const formatCurrency = (value?: number | null) => {
+  if (value == null || Number.isNaN(value)) {
+    return '—';
+  }
+  return `£${value.toFixed(1)}m`;
+};
+
+const formatPercent = (value?: number | null) => {
+  if (value == null || Number.isNaN(value)) {
+    return '—';
+  }
+  return `${value.toFixed(1)}%`;
+};
+
+const formatDate = (isoDate?: string | null) => {
+  if (!isoDate) {
+    return '—';
+  }
+  const parsed = new Date(isoDate);
+  if (Number.isNaN(parsed.getTime())) {
+    return '—';
+  }
+  return parsed.toLocaleDateString();
+};
+
+const MyTeam = () => {
+  const [teamIdInput, setTeamIdInput] = useState(() => {
+    if (typeof window === 'undefined') {
+      return DEFAULT_TEAM_ID.toString();
+    }
+    return window.localStorage.getItem(STORAGE_KEY) ?? DEFAULT_TEAM_ID.toString();
+  });
+
+  const [activeTeamId, setActiveTeamId] = useState<number | null>(() => {
+    if (typeof window === 'undefined') {
+      return DEFAULT_TEAM_ID;
+    }
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return DEFAULT_TEAM_ID;
+    }
+    const parsed = Number.parseInt(stored, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TEAM_ID;
+  });
+
+  const [inputError, setInputError] = useState<string | null>(null);
+
+  const {
+    data,
+    isLoading,
+    isFetching,
+    error,
+    refetch,
+  } = useUserTeam(activeTeamId ?? undefined);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !activeTeamId) {
+      return;
+    }
+    window.localStorage.setItem(STORAGE_KEY, activeTeamId.toString());
+  }, [activeTeamId]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = teamIdInput.trim();
+    if (!trimmed) {
+      setInputError('Please enter your FPL team ID.');
+      return;
+    }
+    const parsed = Number.parseInt(trimmed, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      setInputError('Team IDs must be positive numbers.');
+      return;
+    }
+    setInputError(null);
+    setActiveTeamId(parsed);
+  };
+
+  const startingXI = useMemo(() => {
+    if (!data?.picks) {
+      return [] as UserTeamPick[];
+    }
+    return [...data.picks].sort(
+      (a, b) => (a.position ?? 0) - (b.position ?? 0)
+    );
+  }, [data?.picks]);
+
+  const bench = useMemo(() => {
+    if (data?.bench && data.bench.length > 0) {
+      return [...data.bench].sort(
+        (a, b) => (a.position ?? 0) - (b.position ?? 0)
+      );
+    }
+    if (!data?.picks) {
+      return [] as UserTeamPick[];
+    }
+    return [...data.picks]
+      .filter((pick) => (pick.position ?? 0) > 11)
+      .sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
+  }, [data?.bench, data?.picks]);
+
+  const recentHistory = useMemo(() => {
+    if (!data?.history?.current) {
+      return [] as UserTeamHistoryEntry[];
+    }
+    return [...data.history.current]
+      .filter((entry) => entry.event != null)
+      .sort((a, b) => (b.event ?? 0) - (a.event ?? 0))
+      .slice(0, 6);
+  }, [data?.history?.current]);
+
+  const managerName = useMemo(() => {
+    const first = data?.team?.player_first_name ?? '';
+    const last = data?.team?.player_last_name ?? '';
+    return `${first} ${last}`.trim();
+  }, [data?.team?.player_first_name, data?.team?.player_last_name]);
+
+  const currentEventSummary = data?.current_event_summary;
+  const showInitialSpinner = isLoading && !data;
+  const isRefreshing = isFetching && !isLoading;
+  const queryError = error instanceof Error ? error.message : null;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-2">
+        <h1 className="text-3xl font-bold text-gray-900">My FPL Team</h1>
+        <p className="text-gray-600">
+          Add your Fantasy Premier League manager ID to keep track of your squad and
+          review weekly performance.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Link your team</CardTitle>
+          <CardDescription>
+            Your manager ID appears in the URL on fantasy.premierleague.com. Example:{' '}
+            <span className="font-semibold text-gray-700">266343</span>.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form
+            onSubmit={handleSubmit}
+            className="flex flex-col gap-4 sm:flex-row sm:items-end"
+          >
+            <div className="flex-1">
+              <label htmlFor="teamId" className="block text-sm font-medium text-gray-700">
+                Team ID
+              </label>
+              <input
+                id="teamId"
+                name="teamId"
+                type="text"
+                inputMode="numeric"
+                value={teamIdInput}
+                onChange={(event) => setTeamIdInput(event.target.value)}
+                className="mt-1 w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                placeholder="e.g. 266343"
+              />
+              {inputError ? (
+                <p className="mt-2 text-sm text-red-600">{inputError}</p>
+              ) : (
+                <p className="mt-2 text-xs text-gray-500">
+                  Saving updates your browser so the app remembers your team next time.
+                </p>
+              )}
+            </div>
+            <div className="flex items-center gap-3">
+              <button
+                type="submit"
+                className="inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
+              >
+                <Users className="mr-2 h-4 w-4" /> Save team
+              </button>
+              {activeTeamId ? (
+                <button
+                  type="button"
+                  onClick={() => refetch()}
+                  className="inline-flex items-center rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1"
+                >
+                  <RefreshCcw className="mr-2 h-4 w-4" /> Refresh
+                </button>
+              ) : null}
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      {data?.source === 'sample' && (
+        <div className="flex items-start gap-3 rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+          <Star className="mt-0.5 h-5 w-5 text-amber-500" />
+          <p>
+            Live FPL data was unavailable, so a curated example for team{' '}
+            <span className="font-semibold">266343</span> is shown. Try refreshing when you
+            have an active internet connection to load your latest squad.
+          </p>
+        </div>
+      )}
+
+      {queryError && !data && (
+        <div className="flex items-start gap-3 rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          <AlertCircle className="mt-0.5 h-5 w-5" />
+          <div>
+            <p className="font-semibold">Unable to load team</p>
+            <p>{queryError}</p>
+          </div>
+        </div>
+      )}
+
+      {showInitialSpinner && (
+        <LoadingSpinner message="Fetching your FPL team..." fullHeight />
+      )}
+
+      {!showInitialSpinner && data && (
+        <div className="space-y-6">
+          <Card>
+            <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <CardTitle>{data.team?.name ?? 'Your fantasy squad'}</CardTitle>
+                <CardDescription>
+                  Managed by {managerName || '—'}
+                  {data.team?.player_region_name ? ` • ${data.team.player_region_name}` : ''}
+                </CardDescription>
+                {data.team?.joined_time && (
+                  <p className="mt-1 text-xs text-gray-500">
+                    Joined: {formatDate(data.team.joined_time)}
+                  </p>
+                )}
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                {typeof data.current_event === 'number' && (
+                  <Badge variant="secondary">GW {data.current_event}</Badge>
+                )}
+                {data.team?.favourite_team_name && (
+                  <Badge variant="outline">Favourite club: {data.team.favourite_team_name}</Badge>
+                )}
+                {isRefreshing && <Badge variant="secondary">Refreshing…</Badge>}
+                <Badge variant={data.source === 'live' ? 'default' : 'secondary'}>
+                  {data.source === 'live' ? 'Live data' : 'Sample data'}
+                </Badge>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+                <div className="rounded-lg border border-gray-200 p-4">
+                  <div className="flex items-center justify-between text-sm text-gray-500">
+                    <span>Overall points</span>
+                    <Trophy className="h-4 w-4 text-yellow-500" />
+                  </div>
+                  <p className="mt-1 text-2xl font-semibold text-gray-900">
+                    {formatNumber(data.team?.summary_overall_points)}
+                  </p>
+                </div>
+                <div className="rounded-lg border border-gray-200 p-4">
+                  <p className="text-sm text-gray-500">Overall rank</p>
+                  <p className="mt-1 text-2xl font-semibold text-gray-900">
+                    {formatNumber(data.team?.summary_overall_rank)}
+                  </p>
+                </div>
+                <div className="rounded-lg border border-gray-200 p-4">
+                  <p className="text-sm text-gray-500">Gameweek points</p>
+                  <p className="mt-1 text-2xl font-semibold text-gray-900">
+                    {formatNumber(currentEventSummary?.points ?? data.team?.summary_event_points)}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    Rank: {formatNumber(currentEventSummary?.rank ?? data.team?.summary_event_rank)}
+                  </p>
+                </div>
+                <div className="rounded-lg border border-gray-200 p-4">
+                  <p className="text-sm text-gray-500">Transfers (GW)</p>
+                  <p className="mt-1 text-2xl font-semibold text-gray-900">
+                    {formatNumber(
+                      currentEventSummary?.event_transfers ?? data.team?.summary_event_transfers
+                    )}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    Cost: {formatNumber(
+                      currentEventSummary?.event_transfers_cost ??
+                        data.team?.summary_event_transfers_cost
+                    )}
+                  </p>
+                </div>
+                <div className="rounded-lg border border-gray-200 p-4">
+                  <p className="text-sm text-gray-500">Squad value</p>
+                  <p className="mt-1 text-2xl font-semibold text-gray-900">
+                    {formatCurrency(data.team?.team_value)}
+                  </p>
+                </div>
+                <div className="rounded-lg border border-gray-200 p-4">
+                  <p className="text-sm text-gray-500">In the bank</p>
+                  <p className="mt-1 text-2xl font-semibold text-gray-900">
+                    {formatCurrency(currentEventSummary?.bank ?? data.team?.bank)}
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+            <Card className="lg:col-span-2">
+              <CardHeader>
+                <CardTitle>Starting XI</CardTitle>
+                <CardDescription>The players locked in for this gameweek.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                {startingXI.length > 0 ? (
+                  <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                    {startingXI.map((pick) => {
+                      const key = `${pick.element}-${pick.position}`;
+                      return (
+                        <div
+                          key={key}
+                          className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div>
+                              <p className="text-base font-semibold text-gray-900">
+                                {pick.player.web_name ?? 'Unknown player'}
+                              </p>
+                              <p className="text-sm text-gray-500">
+                                {pick.player.team ?? '—'} • {pick.player.position ?? '—'}
+                              </p>
+                            </div>
+                            <div className="flex gap-1">
+                              {pick.is_captain && <Badge variant="default">C</Badge>}
+                              {pick.is_vice_captain && <Badge variant="secondary">VC</Badge>}
+                            </div>
+                          </div>
+                          <div className="mt-4 grid grid-cols-2 gap-3 text-sm text-gray-600">
+                            <div>
+                              <p className="font-medium text-gray-700">Total points</p>
+                              <p>{formatNumber(pick.player.total_points)}</p>
+                            </div>
+                            <div>
+                              <p className="font-medium text-gray-700">Price</p>
+                              <p>{formatCurrency(pick.player.now_cost)}</p>
+                            </div>
+                            <div>
+                              <p className="font-medium text-gray-700">Selected by</p>
+                              <p>{formatPercent(pick.player.selected_by_percent)}</p>
+                            </div>
+                            <div>
+                              <p className="font-medium text-gray-700">Multiplier</p>
+                              <p>{pick.multiplier ?? 0}x</p>
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <p className="text-sm text-gray-500">No starting lineup available.</p>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Bench</CardTitle>
+                <CardDescription>Players ready to step in if needed.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                {bench.length > 0 ? (
+                  <div className="space-y-3">
+                    {bench.map((pick) => {
+                      const key = `${pick.element}-${pick.position}`;
+                      return (
+                        <div
+                          key={key}
+                          className="rounded-md border border-gray-200 bg-white p-3 shadow-sm"
+                        >
+                          <div className="flex items-center justify-between">
+                            <div>
+                              <p className="text-sm font-semibold text-gray-900">
+                                {pick.player.web_name ?? 'Unknown player'}
+                              </p>
+                              <p className="text-xs text-gray-500">
+                                {pick.player.team ?? '—'} • {pick.player.position ?? '—'}
+                              </p>
+                            </div>
+                            <span className="text-xs font-medium text-gray-500">
+                              Slot {pick.position}
+                            </span>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <p className="text-sm text-gray-500">Bench information is not available.</p>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle>Recent gameweeks</CardTitle>
+                <CardDescription>Last six deadlines and their outcomes.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                {recentHistory.length > 0 ? (
+                  <div className="overflow-x-auto">
+                    <table className="min-w-full divide-y divide-gray-200 text-sm">
+                      <thead className="bg-gray-50">
+                        <tr>
+                          <th className="px-4 py-2 text-left font-semibold text-gray-700">GW</th>
+                          <th className="px-4 py-2 text-left font-semibold text-gray-700">Points</th>
+                          <th className="px-4 py-2 text-left font-semibold text-gray-700">Rank</th>
+                          <th className="px-4 py-2 text-left font-semibold text-gray-700">Overall</th>
+                          <th className="px-4 py-2 text-left font-semibold text-gray-700">Bench</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-100">
+                        {recentHistory.map((entry, index) => (
+                          <tr key={entry.event ?? `event-${index}`} className="bg-white">
+                            <td className="px-4 py-2 font-medium text-gray-900">
+                              GW {formatNumber(entry.event)}
+                            </td>
+                            <td className="px-4 py-2 text-gray-700">
+                              {formatNumber(entry.points)}
+                            </td>
+                            <td className="px-4 py-2 text-gray-700">
+                              {formatNumber(entry.rank)}
+                            </td>
+                            <td className="px-4 py-2 text-gray-700">
+                              {formatNumber(entry.overall_rank)}
+                            </td>
+                            <td className="px-4 py-2 text-gray-700">
+                              {formatNumber(entry.points_on_bench)}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                ) : (
+                  <p className="text-sm text-gray-500">No gameweek history available.</p>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Chip usage</CardTitle>
+                <CardDescription>Track when special chips were used or remain.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                {data.chips && data.chips.length > 0 ? (
+                  <div className="space-y-3">
+                    {data.chips.map((chip, index) => {
+                      const chipInfo = chip as ChipInfo;
+                      const name = chipInfo.name?.replace(/_/g, ' ') ?? 'Unknown chip';
+                      const status = chipInfo.status_for_entry ?? 'available';
+                      const played = chipInfo.played_by_entry ?? false;
+                      const event = chipInfo.event;
+
+                      let helperText = '';
+                      if (played && event != null) {
+                        helperText = `Played in GW ${event}`;
+                      } else if (played) {
+                        helperText = 'Already played';
+                      } else if (event != null) {
+                        helperText = `Scheduled for GW ${event}`;
+                      } else {
+                        helperText = 'Available to use';
+                      }
+
+                      return (
+                        <div
+                          key={`${name}-${index}`}
+                          className="rounded-md border border-gray-200 bg-white p-3 shadow-sm"
+                        >
+                          <p className="text-sm font-semibold capitalize text-gray-900">{name}</p>
+                          <p className="text-xs uppercase text-gray-500">{status}</p>
+                          <p className="mt-1 text-sm text-gray-600">{helperText}</p>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <p className="text-sm text-gray-500">No chip information available.</p>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MyTeam;
+

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,11 @@
-import type { Player, Team, Match, PlayerMatchStats, GameweekSummary } from '../types/fpl';
+import type {
+  Player,
+  Team,
+  Match,
+  PlayerMatchStats,
+  GameweekSummary,
+  UserTeamResponse,
+} from '../types/fpl';
 
 const API_BASE_URL = 'http://localhost:8000/api'; // Will be configurable later
 
@@ -114,6 +121,11 @@ class ApiService {
 
   async searchTeams(query: string): Promise<Team[]> {
     return this.fetchData<Team[]>(`/teams/search?q=${encodeURIComponent(query)}`);
+  }
+
+  async getUserTeam(teamId: number, event?: number): Promise<UserTeamResponse> {
+    const params = event ? `?event=${event}` : '';
+    return this.fetchData<UserTeamResponse>(`/user-teams/${teamId}${params}`);
   }
 }
 

--- a/frontend/src/types/fpl.ts
+++ b/frontend/src/types/fpl.ts
@@ -175,3 +175,85 @@ export interface MatchFilters {
   team?: string;
   finished?: boolean;
 }
+
+// User Team Types
+export interface UserTeamPlayerInfo {
+  id: number | null;
+  web_name: string | null;
+  first_name: string | null;
+  second_name: string | null;
+  team: string | null;
+  team_short_name: string | null;
+  position: string | null;
+  now_cost: number | null;
+  total_points: number | null;
+  selected_by_percent: number | null;
+  event_points?: number | null;
+  status?: string | null;
+}
+
+export interface UserTeamPick {
+  element: number | null;
+  position: number | null;
+  multiplier: number | null;
+  is_captain: boolean;
+  is_vice_captain: boolean;
+  player: UserTeamPlayerInfo;
+}
+
+export interface UserTeamHistoryEntry {
+  event: number | null;
+  points: number | null;
+  total_points: number | null;
+  rank: number | null;
+  overall_rank: number | null;
+  event_transfers: number | null;
+  event_transfers_cost: number | null;
+  bank: number | null;
+  value: number | null;
+  points_on_bench: number | null;
+}
+
+export interface UserTeamPastSeason {
+  season_name: string | null;
+  total_points: number | null;
+  rank: number | null;
+}
+
+export interface UserTeamHistory {
+  current: UserTeamHistoryEntry[];
+  past: UserTeamPastSeason[];
+}
+
+export interface UserTeamSummary {
+  id: number | null;
+  name: string | null;
+  player_first_name: string | null;
+  player_last_name: string | null;
+  player_region_name: string | null;
+  summary_overall_points: number | null;
+  summary_overall_rank: number | null;
+  summary_event_points: number | null;
+  summary_event_rank: number | null;
+  summary_event_transfers: number | null;
+  summary_event_transfers_cost: number | null;
+  current_event: number | null;
+  total_transfers: number | null;
+  team_value: number | null;
+  bank: number | null;
+  favourite_team: number | string | null;
+  favourite_team_name?: string | null;
+  joined_time: string | null;
+}
+
+export interface UserTeamResponse {
+  team: UserTeamSummary;
+  current_event: number | null;
+  current_event_summary: UserTeamHistoryEntry | null;
+  picks: UserTeamPick[];
+  bench: UserTeamPick[];
+  chips: Array<Record<string, unknown>>;
+  history: UserTeamHistory;
+  source: 'live' | 'sample';
+  fetched_at: string;
+}


### PR DESCRIPTION
## Summary
- add an httpx-based service and API route for fetching Fantasy Premier League manager teams with a curated fallback for entry 266343
- create a My Team dashboard page that stores the manager ID locally and visualises squad summary, starting XI, bench, history and chip usage
- update shared types, hooks, services and layout navigation to surface the new functionality across the app

## Testing
- npm run build *(fails: tailwindcss now requires the @tailwindcss/postcss plugin in the current tooling configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cf042bf29c8328b3b797989acc5ba9